### PR TITLE
Use `slack-ruby-client` instead of `slack-api`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,34 +55,7 @@ server.start
 
 Running this script will start a server and keep it running; you may wish to use a tool like [Foreman](http://ddollar.github.io/foreman/) to actually start it and manage it in production.
 
-### Writing a bot
-
-The provided example `SimpleBot` illustrates the main ways to build a bot:
-
-```ruby
-require 'slack_bot_server/bot'
-
-class SlackBotServer::SimpleBot < SlackBotServer::Bot
-  # Set the username displayed in Slack
-  username 'SimpleBot'
-
-  # Respond to mentions in the connected chat room (defaults to #general).
-  # As well as the normal data provided by Slack's API, we add the `message`,
-  # which is the `text` parameter with the username stripped out. For example,
-  # When a user sends 'simple_bot: how are you?', the `message` data contains
-  # only 'how are you'.
-  on_mention do |data|
-    reply text: "You said '#{data['message']}', and I'm frankly fascinated."
-  end
-
-  # Respond to messages sent via IM communication directly with the bot.
-  on_im do
-    reply text: "Hmm, OK, let me get back to you about that."
-  end
-end
-```
-
-### Advanced example
+### Advanced server example
 
 This is a more advanced example of a server script, based on the that used by [Harmonia](https://harmonia.io), the product from which this was extracted.
 
@@ -129,6 +102,49 @@ end
 # and we can add new bots by sending messages using the queue.
 server.start
 ```
+
+### Writing a bot
+
+The provided example `SimpleBot` illustrates the main ways to build a bot:
+
+```ruby
+require 'slack_bot_server/bot'
+
+class SlackBotServer::SimpleBot < SlackBotServer::Bot
+  # Set the username displayed in Slack
+  username 'SimpleBot'
+
+  # Respond to mentions in the connected chat room (defaults to #general).
+  # As well as the normal data provided by Slack's API, we add the `message`,
+  # which is the `text` parameter with the username stripped out. For example,
+  # When a user sends 'simple_bot: how are you?', the `message` data contains
+  # only 'how are you'.
+  on_mention do |data|
+    reply text: "You said '#{data['message']}', and I'm frankly fascinated."
+  end
+
+  # Respond to messages sent via IM communication directly with the bot.
+  on_im do
+    reply text: "Hmm, OK, let me get back to you about that."
+  end
+end
+```
+
+As well as the special `on_mention` and `on_im` blocks, there are a number
+of other hooks that you can use when writing a bot:
+
+* `on :message` -- will fire for every message that's received from Slack in
+  the rooms that this bot is a member of
+* `on :start` -- will fire when the bot establishes a connection to Slack
+  (note that periodic disconnections will occur, so this hook is best used
+  to gather data about the current state of Slack. You should not assume
+  this is the first time the bot has ever connected)
+* `on :finish` -- will fire when the bot is disconnected from Slack. This
+  may be because a disconnection happened, or might be because the bot was
+  removed from the server via the `remove_bot` command. You can check if
+  the bot was accidentally/intermittently disconnected via the `running?`
+  method, which will return true unless the bot was explicitly stopped.
+
 
 ### Managing bots
 

--- a/lib/slack_bot_server/bot.rb
+++ b/lib/slack_bot_server/bot.rb
@@ -114,9 +114,7 @@ class SlackBotServer::Bot
     @client.on :close do |event|
       log "disconnected"
       @connected = false
-      if @running
-        start
-      end
+      run_callbacks(:finish)
     end
 
     @client.start_async
@@ -201,6 +199,12 @@ class SlackBotServer::Bot
 
   on :start do
     load_channels
+  end
+
+  on :finish do
+    if @running
+      start
+    end
   end
 
   def to_s

--- a/slack_bot_server.gemspec
+++ b/slack_bot_server.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "slack-api", "~> 1.1"
+  spec.add_dependency "slack-ruby-client", "~> 0.5"
+  spec.add_dependency "faye-websocket", "~> 0.10"
   spec.add_dependency "multi_json"
 
   spec.add_development_dependency "bundler", "~> 1.10"

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe SlackBotServer::Bot do
 
   describe "#typing" do
     let(:channel_id) { 'im123' }
-    let(:im_list) { [{'id' => channel_id}] }
+    let(:im_list) { [{'id' => channel_id, 'is_im' => true}] }
 
     it "send a typing message via RTM" do
       expect(slack_rtm_api).to receive(:typing).with(include(channel: 'C123'))
@@ -299,7 +299,7 @@ RSpec.describe SlackBotServer::Bot do
 
     describe "on_im" do
       let(:channel_id) { 'im123' }
-      let(:im_list) { [{'id' => channel_id}] }
+      let(:im_list) { [{'id' => channel_id, 'is_im' => true}] }
 
       before do
         instance_check = check
@@ -337,7 +337,7 @@ RSpec.describe SlackBotServer::Bot do
       end
 
       it 'recognises new IM channels created by users' do
-        send_message('type' => 'im_created', 'channel' => {'id' => 'other123'})
+        send_message('type' => 'im_created', 'channel' => {'id' => 'other123', 'is_im' => true})
 
         expect(check).to receive(:call)
         send_message('channel' => 'other123', 'text' => 'we need to talk')


### PR DESCRIPTION
There are some problems with older versions of Faye::Websocket, but
the `slack-api` is bound to an older version (~> 0.9).

This is a work in progress. A few things I'm mulling over:

* there are two layers of callbacks - one in `Slack::Realtime::Client`, and another in `SlackBotServer::Bot`. I don't _think_ they can or should be unified (i.e. `SlackBotServer::Bot` using the same dispatch mechanism), but it'd be good to be _certain_.