### PR TITLE
Reset slack-ruby-client in finish callback when trying to restart bot

### DIFF
--- a/lib/slack_bot_server/bot.rb
+++ b/lib/slack_bot_server/bot.rb
@@ -354,6 +354,7 @@ class SlackBotServer::Bot
 
   on :finish do
     if @running
+      @client = ::Slack::RealTime::Client.new(token: @token)
       start
     end
   end


### PR DESCRIPTION
`slack-ruby-client` fires close event before closing itself
https://github.com/dblock/slack-ruby-client/blob/9d9bfe0ec75b8c1dac3e5ac7e1a8c5049a73e732/lib/slack/real_time/client.rb#L102

So restarting in `close` callback will lead to `ClientAlreadyStartedError` error.

`slack-ruby-bot` resets client in `close` callback before trying to restart bot
https://github.com/dblock/slack-ruby-bot/blob/6ab072fbf1e34f05f5d6ea3e55cd5185b1f39769/lib/slack-ruby-bot/server.rb#L90

I think we should take a similar approach.